### PR TITLE
ci: Add workflow to update major release tag

### DIFF
--- a/.github/workflows/major-release-tag.yml
+++ b/.github/workflows/major-release-tag.yml
@@ -26,7 +26,7 @@ jobs:
       run: |
         VERSION=${GITHUB_REF#refs/tags/}
         MAJOR=${VERSION%%.*}
-        git config --global user.name 'YOUR NAME HERE'
-        git config --global user.email 'USERNAME@users.noreply.github.com'
+        git config --global user.name 'novu-bot'
+        git config --global user.email 'novu-bot@users.noreply.github.com'
         git tag -fa "${MAJOR}" -m 'Update major version tag'
         git push origin "${MAJOR}" --force

--- a/.github/workflows/major-release-tag.yml
+++ b/.github/workflows/major-release-tag.yml
@@ -1,0 +1,32 @@
+# see https://gist.github.com/cicirello/ade1d559a89104140557389365154bc1
+# This action updates forcefully updates and pushes the major release Git tag
+# to the latest release version.
+#
+# This ensures Github action users can use the major release tag to trigger
+# workflows for a given major release, whilst receiving updates from minor and
+# patch releases.
+#
+# Example: v2.0.4 -> v2
+# Example: v2.1.0 -> v2
+
+name: Update Major Release Tag
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  movetag:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Get major version num and update tag
+      run: |
+        VERSION=${GITHUB_REF#refs/tags/}
+        MAJOR=${VERSION%%.*}
+        git config --global user.name 'YOUR NAME HERE'
+        git config --global user.email 'USERNAME@users.noreply.github.com'
+        git tag -fa "${MAJOR}" -m 'Update major version tag'
+        git push origin "${MAJOR}" --force


### PR DESCRIPTION
* Add workflow to update major release tag, ensuring that Github action users can point to a major version like `actions-novu-sync@v2` and always get latest patch and minor version updates. Each release created via Github will trigger the action automatically.